### PR TITLE
Add recommendation for bumping UUID on new versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The `uuid` provides the most stable identification since it remains constant eve
 
 Conventions MAY use a versioning scheme to allow evolution over time. Versioned conventions SHOULD include the version information in the `schema_url` (e.g., `https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json"` to facilitate validation of specific versions. Versioned conventions may include the version in the convention's own properties (not in the Zarr Conventions Metadata object) (`e.g., {'proj:version': "1"}`) for convenient version identification without url parsing. If a convention uses versioning, it MUST clearly define the semantic meaning of version numbers in its specification.
 
+Conventions which do not include version information in the convention's own properties SHOULD use a new UUID when breaking changes are introduced.
+
 ### Convention Properties
 
 Convention properties exist at the root `attributes` level. This enables composability, allowing conventions to extend and reference properties from other conventions.


### PR DESCRIPTION
While working on https://github.com/clbarnes/zarr-convention-thumbnails/pull/3 and github.com/clbarnes/zarrs_conventions , and in discussion with @mkitti , I think that a concrete recommendation on how versioning and UUIDs interacts would be useful.

UUIDs are specified as the preferred identifier but do not confer version information as schema/spec URL can. This means that implementations given only a UUID do not have enough information to actually deserialise conventional metadata. Furthermore, if the schema/spec URL is incremented but the UUID isn't, a convention registry needs to maintain one-to-many mappings of UUIDs to schema/spec URLs which adds complexity.

If version information is present in the conventional metadata, the UUID can remain fixed, but when the UUID is the only indication of how you should deserialise the metadata, it should get bumped with breaking changes (in my opinion).